### PR TITLE
Update Nano S SDK, LLVM and Ubuntu versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 LABEL maintainer="Luke Childs <lukechilds123@gmail.com>"
 
 VOLUME ["/code"]
@@ -21,15 +21,15 @@ RUN echo "Install custom gcc" && \
   rm /tmp/gcc.tar.bz2
 
 RUN echo "Install custom clang" && \
-  curl -L https://releases.llvm.org/4.0.0/clang+llvm-4.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz --output /tmp/clang.tar.xz && \
-  echo "8e920c166b00e7869cea443e305933cc410bd1b982c7c5dc56995b6cffb0586f  /tmp/clang.tar.xz" | sha256sum -c && \
+  curl -L https://releases.llvm.org/7.0.1/clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz --output /tmp/clang.tar.xz && \
+  echo "e74ce06d99ed9ce42898e22d2a966f71ae785bdf4edbded93e628d696858921a  /tmp/clang.tar.xz" | sha256sum -c && \
   tar -xvf /tmp/clang.tar.xz -C ${BOLOS_ENV} && \
-  mv ${BOLOS_ENV}/clang+llvm-4.0.0-x86_64-linux-gnu-ubuntu-16.04 ${BOLOS_ENV}/clang-arm-fropi && \
+  mv ${BOLOS_ENV}/clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04 ${BOLOS_ENV}/clang-arm-fropi && \
   rm /tmp/clang.tar.xz
 
 RUN echo "Install Ledger Nano S SDK" && \
   git clone https://github.com/LedgerHQ/nanos-secure-sdk.git ${BOLOS_SDK} && \
-  cd ${BOLOS_SDK} && git checkout tags/nanos-1421
+  cd ${BOLOS_SDK} && git checkout tags/nanos-1552
 
 COPY ./bin/init /usr/local/bin/init
 

--- a/test
+++ b/test
@@ -22,4 +22,4 @@ docker run -v ${PWD}:/code ledger-sdk
 
 echo
 echo "Checking bin/app.hex checksum..."
-echo "ee5dd7653d67036aa98ecb940b411193c3c5cc58f862c8a325a12dd537350458  bin/app.hex" | shasum --algorithm 256 --check
+echo "bf881e2e2473268fa44fe1c419ae005caf4f16c958f4cb3ea723be563d03b5fa  bin/app.hex" | shasum --algorithm 256 --check


### PR DESCRIPTION
Nano S SDK 1.5.5 still can compile apps with `CX_COMPLIANCE_141`